### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MarekWadinger/text-to-control/security/code-scanning/2](https://github.com/MarekWadinger/text-to-control/security/code-scanning/2)

To fix this problem, we should add an explicit `permissions:` block with the minimum necessary privileges at the top level of the workflow file, so it applies to all jobs within the workflow. For standard CI workflows that just check out code, install dependencies, run linters, tests, and post coverage reports (e.g., with Codecov), only `contents: read` is generally needed by default, unless a specific step/job requires more. Most Codecov actions use their own token (as here), not GITHUB_TOKEN, so no extra permissions are needed. Therefore, we should add the following block right below `name: CI`:

```yaml
permissions:
  contents: read
```

No new methods, imports, or variable definitions are needed—just this addition at the root of the YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
